### PR TITLE
Fixes url built if a path with a leading / is used

### DIFF
--- a/dist/build-url.js
+++ b/dist/build-url.js
@@ -26,7 +26,11 @@
 
     if (options) {
       if (options.path) {
-        builtUrl += '/' + options.path;
+        if (options.path.indexOf('/') === 0) {
+          builtUrl += options.path;
+        } else {
+          builtUrl += '/' + options.path;
+        }
       }
 
       if (options.queryParams) {

--- a/dist/build-url.min.js
+++ b/dist/build-url.min.js
@@ -4,4 +4,4 @@
  * @link https://github.com/steverydz/build-url#readme
  * @license MIT
  */
-(function(){"use strict";var r=this,e=r.buildUrl,t=function(r,e){var t,u,o=[];if(null===r?u="":"object"==typeof r?(u="",e=r):u=r,e){if(e.path&&(u+="/"+e.path),e.queryParams){for(t in e.queryParams)e.queryParams.hasOwnProperty(t)&&o.push(t+"="+e.queryParams[t]);u+="?"+o.join("&")}e.hash&&(u+="#"+e.hash)}return u};t.noConflict=function(){return r.buildUrl=e,t},"undefined"!=typeof exports?("undefined"!=typeof module&&module.exports&&(exports=module.exports=t),exports.buildUrl=t):r.buildUrl=t}).call(this);
+(function(){"use strict";var r=this,e=r.buildUrl,t=function(r,e){var t,u,o=[];if(null===r?u="":"object"==typeof r?(u="",e=r):u=r,e){if(e.path&&(u+=0===e.path.indexOf("/")?e.path:"/"+e.path),e.queryParams){for(t in e.queryParams)e.queryParams.hasOwnProperty(t)&&o.push(t+"="+e.queryParams[t]);u+="?"+o.join("&")}e.hash&&(u+="#"+e.hash)}return u};t.noConflict=function(){return r.buildUrl=e,t},"undefined"!=typeof exports?("undefined"!=typeof module&&module.exports&&(exports=module.exports=t),exports.buildUrl=t):r.buildUrl=t}).call(this);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "build-url",
   "version": "1.0.9",
-  "description": "A small library that builds a URL given it's components",
+  "description": "A small library that builds a URL given its components",
   "main": "./dist/build-url.js",
   "scripts": {
     "test": "./node_modules/jasmine/bin/jasmine.js"

--- a/spec/build-url-spec.js
+++ b/spec/build-url-spec.js
@@ -19,6 +19,12 @@ describe('buildUrl', function () {
     })).toEqual('http://example.com/about/me');
   });
 
+  it('should append a path when passed an option with a leading "/"', function() {
+    expect(buildUrl('http://example.com', {
+      path: '/about/me'
+    })).toEqual('http://example.com/about/me');
+  });
+
   it('should append a query string when passed as an option', function () {
     expect(buildUrl('http://example.com', {
       queryParams: {

--- a/src/build-url.js
+++ b/src/build-url.js
@@ -20,7 +20,11 @@
 
     if (options) {
       if (options.path) {
-        builtUrl += '/' + options.path;
+        if (options.path.indexOf('/') === 0) {
+          builtUrl += options.path;
+        } else {
+          builtUrl += '/' + options.path;
+        }
       }
 
       if (options.queryParams) {


### PR DESCRIPTION
Closes #1.

Hey there! Noticed the other day while I was using this package that paths don't handle leading /'s in the path option. It also looks like another user was having this trouble in "[Incorrect URLs built if a Path with a leading / is used](https://github.com/steverydz/build-url/issues/1)". 

In this PR, I updated a small typo in the `package.json` and another commit to update the lib to handle the path option with leading /. In addition, I've added a spec for this edge case.

```js
/* Before */
buildUrl('', function() {
  path: '/about'
}); // => '//about'

/* After */
buildUrl('', function() {
  path: '/about'
}) // => '/about'
```
