### PR TITLE
Allow users to choose between CSV and separate array query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ buildUrl('http://example.com', {
 // returns http://example.com/about?foo=bar&bar=one,two,three,123#contact
 ```
 
+If you pass an array to the `queryParams` object, and want that they should not be comma separated use `disableCSV`:
+
+```
+buildUrl('http://example.com', {
+  disableCSV: true,
+  queryParams: {
+    foo: 'bar',
+    bar: ['one', 'two', 'three']
+  }
+});
+
+// returns http://example.com?foo=bar&bar=one&bar=two&bar=three
+```
+
+
 If you only want the query string, path, hash, or any combination of the three you can skip the URL parameter or pass in an empty string or null:
 
 ```

--- a/src/build-url.js
+++ b/src/build-url.js
@@ -45,16 +45,22 @@
 
       if (options.queryParams) {
         for (key in options.queryParams) {
-          if (options.queryParams.hasOwnProperty(key)
-              && options.queryParams[key] !== void 0) {
-                var encodedParam;
-                  if (caseChange) {
-                    encodedParam = encodeURIComponent(String(options.queryParams[key]).trim().toLowerCase());  
-                  }
-                  else {
-                    encodedParam = encodeURIComponent(String(options.queryParams[key]).trim()); 
-                  }
-            queryString.push(key + '=' + encodedParam);
+          if (options.queryParams.hasOwnProperty(key) && options.queryParams[key] !== void 0) {
+            var encodedParam;
+            if (options.disableCSV && Array.isArray(options.queryParams[key]) && options.queryParams[key].length) {
+              for(var i = 0; i < options.queryParams[key].length; i++) {
+                encodedParam = encodeURIComponent(String(options.queryParams[key][i]).trim());
+                queryString.push(key + '=' + encodedParam);
+              }
+            } else {              
+              if (caseChange) {
+                encodedParam = encodeURIComponent(String(options.queryParams[key]).trim().toLowerCase());
+              }
+              else {
+                encodedParam = encodeURIComponent(String(options.queryParams[key]).trim());
+              }
+              queryString.push(key + '=' + encodedParam);
+            }
           }
         }
         builtUrl += '?' + queryString.join('&');


### PR DESCRIPTION
By default the array fields inside the `queryParams` would encode to a comma separated list of values.

Users should also have the option to use separate param for each of the value inside the array. Which would cater to a wider use case.

Currently it works like this:
```
buildUrl('http://example.com', {
  queryParams: {
    foo: 'bar',
    bar: ['one', 'two', 'three']
  }
});

// returns http://example.com?foo=bar&bar=one,two,three
```

Users might also want the following:
```
buildUrl('http://example.com', {
  disableCSV: true,
  queryParams: {
    foo: 'bar',
    bar: ['one', 'two', 'three']
  }
});

// returns http://example.com?foo=bar&bar=one&bar=two&bar=three
```