### PR TITLE
Fixes main value in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "build-url",
   "version": "5.0.2",
   "description": "A small library that builds a URL given its components",
-  "main": "./src/build-url.js",
+  "main": "./dist/build-url.js",
   "scripts": {
     "build": "webpack",
     "lint-js": "eslint src/**/*.js",


### PR DESCRIPTION
The value of the main key in package.json points to the file in 'src', which is not packaged, while it should be 'dist'.