### PR TITLE
add typescript definition for single parameter variant

### DIFF
--- a/build-url.d.ts
+++ b/build-url.d.ts
@@ -9,6 +9,10 @@ declare function BuildUrl(
   options?: BuildUrl.BuildUrlOptions
 ): string;
 
+declare function BuildUrl(
+  options: BuildUrl.BuildUrlOptions
+): string;
+
 declare namespace BuildUrl {
   export interface BuildUrlOptions {
     path?: string;


### PR DESCRIPTION
The single parameter variant of the function call is documented in README:

```ts
buildUrl({
  queryParams: {
    foo: 'bar',
    bar: 'baz'
  }
});
```

but not currently allowed by typescript definitions. The PR fixes that.